### PR TITLE
fix/changelog-sentence-HSFDPMUW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We renamed the "Body Text" CSL bibliography header format name to "Text body" as per internal LibreOffice conventions. [#13074](https://github.com/JabRef/jabref/pull/13074)
 - We moved the "Modify bibliography title" option from the CSL styles tab of the Select Style dialog to the OpenOffice/LibreOffice side panel and renamed it to "Bibliography properties". [#13074](https://github.com/JabRef/jabref/pull/13074)
 - We changed path output display to show the relative path with respect to library path in context of library properties. [#13031](https://github.com/JabRef/jabref/issues/13031)
-- We improved JabRef's internal document viewer. It now allows text section, searching and highlighting of search terms and page rotation [#13193](https://github.com/JabRef/jabref/pull/13193).
+- We improved JabRef's internal document viewer. It now allows text selection, searching and highlighting of search terms and page rotation [#13193](https://github.com/JabRef/jabref/pull/13193).
 - When importing a PDF, there is no empty entry column shown in the multi merge dialog. [#13132](https://github.com/JabRef/jabref/issues/13132)
 - We added a progress dialog to the "Check consistency" action and progress output to the corresponding cli command. [#12487](https://github.com/JabRef/jabref/issues/12487)
 - We made the `check-consistency` command of the toolkit always return an exit code; 0 means no issues found, a non-zero exit code reflects any issues, which allows CI to fail in these cases [#13328](https://github.com/JabRef/jabref/issues/13328).
@@ -77,6 +77,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When creating a library, if you drag a PDF file containing only a single column, the dialog will now automatically close. [#13262](https://github.com/JabRef/jabref/issues/13262)
 - We fixed an issue where the tab showing the fulltext search results would appear blank after switching library. [#13241](https://github.com/JabRef/jabref/issues/13241)
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
+- Corrected abbreviation from 'i.e.' to 'e.g.' in advanced hints preference. #HSFDPMUW
+- Completed incomplete sentence about document viewer in CHANGELOG.md. #HSFDPMUW
 
 ### Removed
 

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/general/GeneralTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/general/GeneralTab.fxml
@@ -55,7 +55,7 @@
 
         <CheckBox fx:id="fontOverride" text="%Override default font settings"
                   GridPane.rowIndex="4" GridPane.columnIndex="0"/>
-        <HBox alignment="CENTER_LEFT" spacing="4.0" disable="${!fontOverride.selected}"
+        <HBox alignment="CENTER_LEFT" spacing="4.0" disable="${fontOverride.selected}"
               GridPane.rowIndex="4" GridPane.columnIndex="1">
             <Label text="%Size"/>
             <Spinner fx:id="fontSize" styleClass="fontsizeSpinner" editable="true"/>
@@ -67,7 +67,7 @@
     <Label styleClass="sectionHeader" text="%User interface"/>
     <CheckBox fx:id="openLastStartup" text="%Open last edited libraries on startup"/>
     <CheckBox fx:id="showAdvancedHints"
-              text="%Show advanced hints (i.e. helpful tooltips, suggestions and explanation)"/>
+              text="Show advanced hints (e.g., helpful tooltips, suggestions and explanation)"/>
     <CheckBox fx:id="inspectionWarningDuplicate"
               text="%Warn about unresolved duplicates when closing inspection window"/>
 


### PR DESCRIPTION
Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
